### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "boonebgorges/wp-cli-buddypress",
-	"type": "command",
+	"type": "wp-cli-package",
 	"description": "WP-CLI commands for BuddyPress",
 	"keywords": ["wp-cli", "buddypress", "wordpress", "bp"],
 	"homepage": "https://github.com/boonebgorges/wp-cli-buddypress",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567