### PR TITLE
Register commands before WordPress is loaded

### DIFF
--- a/wp-cli-bp.php
+++ b/wp-cli-bp.php
@@ -3,10 +3,11 @@
 // Bail if WP-CLI is not present
 if ( !defined( 'WP_CLI' ) ) return;
 
-require_once( __DIR__ . '/component.php' );
-require_once( __DIR__ . '/components/activity.php' );
-require_once( __DIR__ . '/components/core.php' );
-require_once( __DIR__ . '/components/group.php' );
-require_once( __DIR__ . '/components/member.php' );
-require_once( __DIR__ . '/components/xprofile.php' );
-
+WP_CLI::add_hook( 'before_wp_load', function(){
+	require_once( __DIR__ . '/component.php' );
+	require_once( __DIR__ . '/components/activity.php' );
+	require_once( __DIR__ . '/components/core.php' );
+	require_once( __DIR__ . '/components/group.php' );
+	require_once( __DIR__ . '/components/member.php' );
+	require_once( __DIR__ . '/components/xprofile.php' );
+});


### PR DESCRIPTION
Bit of a hack, but this ensures WP-CLI is loaded and will work with both v1.2.0 and v1.1.0.

See #18