### PR TITLE
Fixing fatal error: class WP_CLI\CommandWithDBOject not found

### DIFF
--- a/wp-cli-bp.php
+++ b/wp-cli-bp.php
@@ -1,12 +1,15 @@
 <?php
 
-// Bail if WP-CLI is not present
-if ( !defined( 'WP_CLI' ) ) return;
+// Bail if WP-CLI is not present.
+if ( ! defined( 'WP_CLI' ) ) {
+	return;
+}
 
-require_once( __DIR__ . '/component.php' );
-require_once( __DIR__ . '/components/activity.php' );
-require_once( __DIR__ . '/components/core.php' );
-require_once( __DIR__ . '/components/group.php' );
-require_once( __DIR__ . '/components/member.php' );
-require_once( __DIR__ . '/components/xprofile.php' );
-
+WP_CLI::add_hook( 'before_wp_load', function() {
+	require_once( __DIR__ . '/component.php' );
+	require_once( __DIR__ . '/components/activity.php' );
+	require_once( __DIR__ . '/components/core.php' );
+	require_once( __DIR__ . '/components/group.php' );
+	require_once( __DIR__ . '/components/member.php' );
+	require_once( __DIR__ . '/components/xprofile.php' );
+});


### PR DESCRIPTION
It fixes #18.